### PR TITLE
#6 feat: 로그아웃 및 회원탈퇴 API 생성

### DIFF
--- a/src/main/java/com/mychore/mychore_server/controller/UserController.java
+++ b/src/main/java/com/mychore/mychore_server/controller/UserController.java
@@ -33,6 +33,22 @@ public class UserController {
         return ResponseCustom.OK(userService.login(userLogInReq));
     }
 
+    // 로그아웃
+    @Auth
+    @PatchMapping("/logout")
+    public ResponseCustom<Void> logOut(@IsLogin LoginStatus loginStatus){
+        userService.logout(loginStatus.getUserId());
+        return ResponseCustom.OK();
+    }
+
+    // 회원탈퇴
+    @Auth
+    @DeleteMapping
+    public ResponseCustom<Void> withdraw(@IsLogin LoginStatus loginStatus){
+        userService.withdraw(loginStatus.getUserId());
+        return ResponseCustom.OK();
+    }
+
     // 프로필 조회
     @Auth
     @GetMapping

--- a/src/main/java/com/mychore/mychore_server/controller/UserController.java
+++ b/src/main/java/com/mychore/mychore_server/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
     // 알림 설정 수정
     @Auth
     @PatchMapping("/noti")
-    public ResponseCustom<Void> editNotiAgree(Integer type, @IsLogin LoginStatus loginStatus){
+    public ResponseCustom<Void> editNotiAgree(String type, @IsLogin LoginStatus loginStatus){
         userService.editNotiAgree(loginStatus.getUserId(), type);
         return ResponseCustom.OK();
     }

--- a/src/main/java/com/mychore/mychore_server/controller/UserController.java
+++ b/src/main/java/com/mychore/mychore_server/controller/UserController.java
@@ -11,7 +11,6 @@ import com.mychore.mychore_server.global.resolver.LoginStatus;
 import com.mychore.mychore_server.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,5 +39,11 @@ public class UserController {
                                                     @IsLogin LoginStatus loginStatus){
         userService.editProfile(loginStatus.getUserId(), patchProfileReq);
         return ResponseCustom.OK();
+    }
+
+    // 가입 전 닉네임 중복 확인
+    @GetMapping("check-nickname")
+    public ResponseCustom<Boolean> checkNickname(String nickname){
+        return ResponseCustom.OK(userService.checkNicknameWithSignUp(nickname));
     }
 }

--- a/src/main/java/com/mychore/mychore_server/controller/UserController.java
+++ b/src/main/java/com/mychore/mychore_server/controller/UserController.java
@@ -4,6 +4,7 @@ import com.mychore.mychore_server.dto.ResponseCustom;
 import com.mychore.mychore_server.dto.user.request.PatchProfileReq;
 import com.mychore.mychore_server.dto.user.request.UserLogInReq;
 import com.mychore.mychore_server.dto.user.request.UserSignUpReq;
+import com.mychore.mychore_server.dto.user.response.GetProfileRes;
 import com.mychore.mychore_server.dto.user.response.UserTokenRes;
 import com.mychore.mychore_server.global.resolver.Auth;
 import com.mychore.mychore_server.global.resolver.IsLogin;
@@ -30,6 +31,13 @@ public class UserController {
     @PostMapping("/login")
     public ResponseCustom<UserTokenRes> logIn(@RequestBody @Valid UserLogInReq userLogInReq){
         return ResponseCustom.OK(userService.login(userLogInReq));
+    }
+
+    // 프로필 조회
+    @Auth
+    @GetMapping
+    public ResponseCustom<GetProfileRes> getProfile(@IsLogin LoginStatus loginStatus){
+        return ResponseCustom.OK(userService.getProfile(loginStatus.getUserId()));
     }
 
     // 프로필 수정

--- a/src/main/java/com/mychore/mychore_server/controller/UserController.java
+++ b/src/main/java/com/mychore/mychore_server/controller/UserController.java
@@ -43,9 +43,17 @@ public class UserController {
     // 프로필 수정
     @Auth
     @PatchMapping
-    public ResponseCustom<UserTokenRes> editProfile(@RequestBody @Valid PatchProfileReq patchProfileReq,
+    public ResponseCustom<Void> editProfile(@RequestBody @Valid PatchProfileReq patchProfileReq,
                                                     @IsLogin LoginStatus loginStatus){
         userService.editProfile(loginStatus.getUserId(), patchProfileReq);
+        return ResponseCustom.OK();
+    }
+
+    // 알림 설정 수정
+    @Auth
+    @PatchMapping("/noti")
+    public ResponseCustom<Void> editNotiAgree(Integer type, @IsLogin LoginStatus loginStatus){
+        userService.editNotiAgree(loginStatus.getUserId(), type);
         return ResponseCustom.OK();
     }
 

--- a/src/main/java/com/mychore/mychore_server/dto/user/UserAssembler.java
+++ b/src/main/java/com/mychore/mychore_server/dto/user/UserAssembler.java
@@ -1,6 +1,7 @@
 package com.mychore.mychore_server.dto.user;
 
 import com.mychore.mychore_server.dto.user.request.UserSignUpReq;
+import com.mychore.mychore_server.dto.user.response.GetProfileRes;
 import com.mychore.mychore_server.entity.user.User;
 import com.mychore.mychore_server.entity.user.UserAgree;
 import com.mychore.mychore_server.exception.user.InvalidNicknameException;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -33,6 +35,16 @@ public class UserAssembler {
                 .user(user)
                 .is14Over(userSignUpReq.getIs14Over())
                 .acceptEmailDate(userSignUpReq.getIsAcceptEmail() ? LocalDateTime.now() : null)
+                .build();
+    }
+
+    public GetProfileRes toGetProfileDto(User user){
+        return GetProfileRes.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .imgKey(user.getImgKey())
+                .gender(user.getGender().getGenderName())
+                .birth(user.getBirth().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .build();
     }
 

--- a/src/main/java/com/mychore/mychore_server/dto/user/response/GetProfileRes.java
+++ b/src/main/java/com/mychore/mychore_server/dto/user/response/GetProfileRes.java
@@ -1,0 +1,24 @@
+package com.mychore.mychore_server.dto.user.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class GetProfileRes {
+    private String nickname;
+    private String email;
+    private String imgKey;
+    private String gender;
+    private String birth;
+
+    @Builder
+    public GetProfileRes(String nickname, String email, String imgKey, String gender, String birth) {
+        this.nickname = nickname;
+        this.email = email;
+        this.imgKey = imgKey;
+        this.gender = gender;
+        this.birth = birth;
+    }
+}

--- a/src/main/java/com/mychore/mychore_server/entity/BaseEntity.java
+++ b/src/main/java/com/mychore/mychore_server/entity/BaseEntity.java
@@ -23,7 +23,7 @@ public class BaseEntity implements Serializable {
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updateAt;
+    private LocalDateTime updatedAt;
 
     @Setter
     @Column(nullable = false, columnDefinition = "varchar(10) default 'active'")

--- a/src/main/java/com/mychore/mychore_server/entity/user/User.java
+++ b/src/main/java/com/mychore/mychore_server/entity/user/User.java
@@ -8,14 +8,18 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
+
+import static com.mychore.mychore_server.global.constants.Constant.INACTIVE_STATUS;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 @DynamicUpdate
 @Getter
+@SQLDelete(sql = "UPDATE user SET status = 'inactive', updated_at = current_timestamp WHERE user_id = ?")
 public class User extends BaseEntity {
 
     @Id
@@ -62,16 +66,30 @@ public class User extends BaseEntity {
     public void editGender(String gender) {
         this.gender = Gender.getByName(gender);
     }
+
     public void editBirth(String date) {
         this.birth = LocalDate.parse(date);
     }
+
     public void editNickname(String nickname) {
         this.nickname = nickname;
     }
+
     public void editImgKey(String imgKey) {
         this.imgKey = imgKey;
     }
+
     public void updateRefreshToken(String refreshToken){
         this.refreshToken = refreshToken;
     }
+
+    public void removeTokens() {
+        this.refreshToken = null;
+    }
+
+    public void withdraw() {
+        removeTokens();
+        this.setStatus(INACTIVE_STATUS);
+    }
+
 }

--- a/src/main/java/com/mychore/mychore_server/entity/user/UserAgree.java
+++ b/src/main/java/com/mychore/mychore_server/entity/user/UserAgree.java
@@ -31,21 +31,30 @@ public class UserAgree extends BaseEntity {
 
     private LocalDateTime acceptEmailDate;
 
+    // 집안일 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
-    private Boolean isAcceptTodayNoti = true;
+    private Boolean isAgreeChoreNoti = true;
 
+    // 오늘의 집안일 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
-    private Boolean isAcceptNewUserNoti = true;
+    private Boolean isAgreeTodayNoti = true;
 
+    // 그룹원 추가 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
-    private Boolean isAcceptDoneNoti = true;
+    private Boolean isAgreeNewUserNoti = true;
 
+    // 그룹원의 집안일 완료 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
-    private Boolean isAcceptDeleteNoti = true;
+    private Boolean isAgreeDoneNoti = true;
+
+    // 그룹 삭제 알림
+    @NonNull
+    @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    private Boolean isAgreeDeleteNoti = true;
 
     @Builder
     public UserAgree(@NonNull User user, @NonNull Boolean is14Over, LocalDateTime acceptEmailDate) {

--- a/src/main/java/com/mychore/mychore_server/entity/user/UserAgree.java
+++ b/src/main/java/com/mychore/mychore_server/entity/user/UserAgree.java
@@ -34,26 +34,31 @@ public class UserAgree extends BaseEntity {
     // 집안일 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    @Setter
     private Boolean isAgreeChoreNoti = true;
 
     // 오늘의 집안일 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    @Setter
     private Boolean isAgreeTodayNoti = true;
 
     // 그룹원 추가 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    @Setter
     private Boolean isAgreeNewUserNoti = true;
 
     // 그룹원의 집안일 완료 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    @Setter
     private Boolean isAgreeDoneNoti = true;
 
     // 그룹 삭제 알림
     @NonNull
     @Column(columnDefinition = "BOOLEAN DEFAULT true")
+    @Setter
     private Boolean isAgreeDeleteNoti = true;
 
     @Builder

--- a/src/main/java/com/mychore/mychore_server/exception/user/UserExceptionController.java
+++ b/src/main/java/com/mychore/mychore_server/exception/user/UserExceptionController.java
@@ -33,6 +33,11 @@ public class UserExceptionController {
         log.error(e.getMessage());
         return ResponseCustom.BAD_REQUEST(e.getMessage());
     }
+    @ExceptionHandler(WrongNotiTypeException.class)
+    public ResponseCustom<Void> catchWrongNotiTypeException(WrongNotiTypeException e) {
+        log.error(e.getMessage());
+        return ResponseCustom.BAD_REQUEST(e.getMessage());
+    }
     @ExceptionHandler(AuthAnnotationIsNowhereException.class)
     public ResponseCustom<Void> catchAuthAnnotationIsNowhereException(AuthAnnotationIsNowhereException e) {
         log.error(e.getMessage());

--- a/src/main/java/com/mychore/mychore_server/exception/user/WrongNotiTypeException.java
+++ b/src/main/java/com/mychore/mychore_server/exception/user/WrongNotiTypeException.java
@@ -1,0 +1,7 @@
+package com.mychore.mychore_server.exception.user;
+
+public class WrongNotiTypeException extends RuntimeException {
+  public WrongNotiTypeException(){
+    super("알림 타입이 잘못되었습니다.");
+  }
+}

--- a/src/main/java/com/mychore/mychore_server/global/constants/Constant.java
+++ b/src/main/java/com/mychore/mychore_server/global/constants/Constant.java
@@ -5,4 +5,13 @@ public final class Constant {
     public static final String INACTIVE_STATUS = "inactive";
     public static final String JWT_EXPIRED = "JWT_EXPIRED";
     public static final String COMMA = ",";
+
+    public static class User{
+        // 알림 종류
+        public static final String CHORE = "chore";
+        public static final String DONE_CHORE = "done";
+        public static final String TODAY = "today";
+        public static final String NEW_USER = "new-user";
+        public static final String DELETE = "delete";
+    }
 }

--- a/src/main/java/com/mychore/mychore_server/repository/UserAgreeRepository.java
+++ b/src/main/java/com/mychore/mychore_server/repository/UserAgreeRepository.java
@@ -1,11 +1,12 @@
 package com.mychore.mychore_server.repository;
 
-
 import com.mychore.mychore_server.entity.user.UserAgree;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserAgreeRepository extends JpaRepository<UserAgree, Long> {
-
+    Optional<UserAgree> findByUserIdAndStatus(Long userId, String status);
 }

--- a/src/main/java/com/mychore/mychore_server/service/UserService.java
+++ b/src/main/java/com/mychore/mychore_server/service/UserService.java
@@ -49,6 +49,20 @@ public class UserService {
         return UserTokenRes.toDto(jwtUtils.createToken(user));
     }
 
+    // 로그아웃
+    public void logout(Long userId) {
+        User user = userRepository.findByIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
+        user.removeTokens();
+        userRepository.save(user);
+    }
+
+    // 회원탈퇴
+    public void withdraw(Long userId) {
+        User user = userRepository.findByIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
+        user.withdraw();
+        userRepository.save(user);
+    }
+
     // 프로필 조회
     public GetProfileRes getProfile(Long userId) {
         User user = userRepository.findByIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/mychore/mychore_server/service/UserService.java
+++ b/src/main/java/com/mychore/mychore_server/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
     public UserTokenRes signUp(UserSignUpReq userSignUpReq) {
         if (userRepository.findByEmailAndStatus(userSignUpReq.getEmail(), ACTIVE_STATUS).isPresent()) {
             throw new EmailAlreadyExistException();
-        } else if (checkNicknameWithSignUp(userSignUpReq.getNickname())) {
+        } else if (!checkNicknameWithSignUp(userSignUpReq.getNickname())) {
             throw new NicknameAlreadyExistException();
         } else {
             User user = userRepository.save(userAssembler.toEntity(userSignUpReq));
@@ -53,7 +53,7 @@ public class UserService {
     // 프로필 수정
     public void editProfile(Long userId, PatchProfileReq patchProfileReq) {
         User user = userRepository.findByIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
-        if (!checkNicknameWithEdit(patchProfileReq.getNickname(), userId)){
+        if (checkNicknameWithEdit(patchProfileReq.getNickname(), userId)){
             user.editProfile(patchProfileReq);
             userRepository.save(user);
         } else throw new NicknameAlreadyExistException();
@@ -62,12 +62,12 @@ public class UserService {
     // 가입 시 닉네임 중복체크
     public boolean checkNicknameWithSignUp(String nickname){
         userAssembler.isValidNickname(nickname);
-        return userRepository.findByNicknameAndStatus(nickname, ACTIVE_STATUS).isPresent();
+        return userRepository.findByNicknameAndStatus(nickname, ACTIVE_STATUS).isEmpty();
     }
 
     // 프로필 수정 시 닉네임 중복체크
-    public boolean checkNicknameWithEdit(String nickname, Long userId){
+    private boolean checkNicknameWithEdit(String nickname, Long userId){
         userAssembler.isValidNickname(nickname);
-        return userRepository.findByNicknameAndStatusAndIdNot(nickname, ACTIVE_STATUS, userId).isPresent();
+        return userRepository.findByNicknameAndStatusAndIdNot(nickname, ACTIVE_STATUS, userId).isEmpty();
     }
 }

--- a/src/main/java/com/mychore/mychore_server/service/UserService.java
+++ b/src/main/java/com/mychore/mychore_server/service/UserService.java
@@ -3,6 +3,7 @@ package com.mychore.mychore_server.service;
 import com.mychore.mychore_server.dto.user.UserAssembler;
 import com.mychore.mychore_server.dto.user.request.PatchProfileReq;
 import com.mychore.mychore_server.dto.user.request.UserLogInReq;
+import com.mychore.mychore_server.dto.user.response.GetProfileRes;
 import com.mychore.mychore_server.dto.user.response.UserTokenRes;
 import com.mychore.mychore_server.dto.user.request.UserSignUpReq;
 import com.mychore.mychore_server.entity.user.User;
@@ -48,6 +49,12 @@ public class UserService {
         User user = userRepository.findByEmailAndProviderAndStatus(userLogInReq.getEmail(), Provider.getByName(userLogInReq.getProvider()), ACTIVE_STATUS)
                 .orElseThrow(EmailNotExistException::new);
         return UserTokenRes.toDto(jwtUtils.createToken(user));
+    }
+
+    // 프로필 조회
+    public GetProfileRes getProfile(Long userId) {
+        User user = userRepository.findByIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
+        return userAssembler.toGetProfileDto(user);
     }
 
     // 프로필 수정

--- a/src/main/java/com/mychore/mychore_server/service/UserService.java
+++ b/src/main/java/com/mychore/mychore_server/service/UserService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.mychore.mychore_server.global.constants.Constant.ACTIVE_STATUS;
+import static com.mychore.mychore_server.global.constants.Constant.User.*;
 
 @Service
 @RequiredArgsConstructor
@@ -80,14 +81,14 @@ public class UserService {
 
     // 알림 설정 수정
     @Transactional
-    public void editNotiAgree(Long userId, Integer type) {
+    public void editNotiAgree(Long userId, String type) {
         UserAgree userAgree = userAgreeRepository.findByUserIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
         switch (type) {
-            case 1 -> userAgree.setIsAgreeChoreNoti(!userAgree.getIsAgreeChoreNoti());
-            case 2 -> userAgree.setIsAgreeDoneNoti(!userAgree.getIsAgreeDoneNoti());
-            case 3 -> userAgree.setIsAgreeTodayNoti(!userAgree.getIsAgreeTodayNoti());
-            case 4 -> userAgree.setIsAgreeNewUserNoti(!userAgree.getIsAgreeNewUserNoti());
-            case 5 -> userAgree.setIsAgreeDeleteNoti(!userAgree.getIsAgreeDeleteNoti());
+            case CHORE -> userAgree.setIsAgreeChoreNoti(!userAgree.getIsAgreeChoreNoti());
+            case DONE_CHORE -> userAgree.setIsAgreeDoneNoti(!userAgree.getIsAgreeDoneNoti());
+            case TODAY -> userAgree.setIsAgreeTodayNoti(!userAgree.getIsAgreeTodayNoti());
+            case NEW_USER -> userAgree.setIsAgreeNewUserNoti(!userAgree.getIsAgreeNewUserNoti());
+            case DELETE -> userAgree.setIsAgreeDeleteNoti(!userAgree.getIsAgreeDeleteNoti());
             default -> throw new WrongNotiTypeException();
         }
     }

--- a/src/main/java/com/mychore/mychore_server/service/UserService.java
+++ b/src/main/java/com/mychore/mychore_server/service/UserService.java
@@ -7,10 +7,8 @@ import com.mychore.mychore_server.dto.user.response.GetProfileRes;
 import com.mychore.mychore_server.dto.user.response.UserTokenRes;
 import com.mychore.mychore_server.dto.user.request.UserSignUpReq;
 import com.mychore.mychore_server.entity.user.User;
-import com.mychore.mychore_server.exception.user.EmailAlreadyExistException;
-import com.mychore.mychore_server.exception.user.EmailNotExistException;
-import com.mychore.mychore_server.exception.user.NicknameAlreadyExistException;
-import com.mychore.mychore_server.exception.user.UserNotFoundException;
+import com.mychore.mychore_server.entity.user.UserAgree;
+import com.mychore.mychore_server.exception.user.*;
 import com.mychore.mychore_server.global.constants.Provider;
 import com.mychore.mychore_server.global.utils.JwtUtils;
 import com.mychore.mychore_server.repository.UserAgreeRepository;
@@ -64,6 +62,20 @@ public class UserService {
             user.editProfile(patchProfileReq);
             userRepository.save(user);
         } else throw new NicknameAlreadyExistException();
+    }
+
+    // 알림 설정 수정
+    @Transactional
+    public void editNotiAgree(Long userId, Integer type) {
+        UserAgree userAgree = userAgreeRepository.findByUserIdAndStatus(userId, ACTIVE_STATUS).orElseThrow(UserNotFoundException::new);
+        switch (type) {
+            case 1 -> userAgree.setIsAgreeChoreNoti(!userAgree.getIsAgreeChoreNoti());
+            case 2 -> userAgree.setIsAgreeDoneNoti(!userAgree.getIsAgreeDoneNoti());
+            case 3 -> userAgree.setIsAgreeTodayNoti(!userAgree.getIsAgreeTodayNoti());
+            case 4 -> userAgree.setIsAgreeNewUserNoti(!userAgree.getIsAgreeNewUserNoti());
+            case 5 -> userAgree.setIsAgreeDeleteNoti(!userAgree.getIsAgreeDeleteNoti());
+            default -> throw new WrongNotiTypeException();
+        }
     }
 
     // 가입 시 닉네임 중복체크


### PR DESCRIPTION
## 💻 작업/변경 내용
- BaseEntity updateAt -> updatedAt 변경
- User 엔티티에 `@SQLDelete` 어노테이션 달아서 soft delete 되도록 설정해놨습니다. cascade 설정은 다음에~
## 💬 기타 사항
- 너무 간단해서 한 브랜치에서 API 두개 만들었어용
